### PR TITLE
release/v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Accepted values for booleans are: "1", "t", "T", "true", "TRUE", "True", "0", "f
 | ANKA_CLOUD_SSH_CONNECTION_ATTEMPT_DELAY | ❌ | Number | The delay between ssh connection attempts in seconds. Defaults to `5` |
 | ANKA_CLOUD_SSH_USER_NAME | ❌ | String | SSH user name to use inside VM. Defaults to "anka". This can also be set via a command line flags to prevent this value from being exposed to the job. See example below. |
 | ANKA_CLOUD_SSH_PASSWORD | ❌ | String | SSH password to use inside VM. Defaults to "admin". This can also be set via a command line flags to prevent this value from being exposed to the job. See example below. |
+| ANKA_CLOUD_QUIETER_LOGGING | ❌ | Boolean | Reduce verbosity of the job logs. Defaults to `false` |
 
 To prevent SSH credentials from being exposed to the job log, they can instead be specified via command line arguments in the config.toml > runner.custom:
 

--- a/internal/ankacloud/client.go
+++ b/internal/ankacloud/client.go
@@ -62,7 +62,7 @@ func (c *APIClient) Post(ctx context.Context, endpoint string, payload interface
 	}
 
 	for k, v := range c.CustomHttpHeaders {
-		log.Debugf("Setting custom header %s: %s\n", k, v)
+		log.Printf("Setting custom header %s: %s\n", k, v)
 		req.Header.Set(k, v)
 	}
 

--- a/internal/ankacloud/client.go
+++ b/internal/ankacloud/client.go
@@ -62,7 +62,7 @@ func (c *APIClient) Post(ctx context.Context, endpoint string, payload interface
 	}
 
 	for k, v := range c.CustomHttpHeaders {
-		log.Printf("Setting custom header %s: %s\n", k, v)
+		log.Debugf("Setting custom header %s: %s\n", k, v)
 		req.Header.Set(k, v)
 	}
 

--- a/internal/ankacloud/tls.go
+++ b/internal/ankacloud/tls.go
@@ -4,12 +4,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/veertuinc/anka-cloud-gitlab-executor/internal/log"
 )
 
 func configureTLS(config APIClientConfig) (*tls.Config, error) {
-	log.Println("handling TLS configuration")
+	log.Debugln("handling TLS configuration")
 
 	tlsConfig := &tls.Config{}
 	caCertPool, _ := x509.SystemCertPool()
@@ -22,11 +23,11 @@ func configureTLS(config APIClientConfig) (*tls.Config, error) {
 		if err := appendRootCert(config.CaCertPath, caCertPool); err != nil {
 			return nil, fmt.Errorf("failed to add CA cert from %q to pool: %w", config.CaCertPath, err)
 		}
-		log.Printf("added CA cert at %q\n", config.CaCertPath)
+		log.ConditionalColorf("using CA cert from %q\n", config.CaCertPath)
 	}
 
 	if config.SkipTLSVerify {
-		log.Println("allowing to skip server host verification")
+		log.ConditionalColorf("allowing to skip server host verification")
 		tlsConfig.InsecureSkipVerify = true
 	}
 

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -26,10 +26,10 @@ var cleanupCommand = &cobra.Command{
 func executeCleanup(ctx context.Context, env gitlab.Environment) error {
 	log.SetOutput(os.Stdout)
 
-	log.Println("running cleanup stage")
+	log.Debugln("running cleanup stage")
 
 	if env.KeepAliveOnError && env.GitlabJobStatus == gitlab.JobStatusFailed {
-		log.Println("keeping VM alive on error")
+		log.Colorln("keeping VM alive on error")
 		return nil
 	}
 
@@ -45,7 +45,7 @@ func executeCleanup(ctx context.Context, env gitlab.Environment) error {
 	if err != nil {
 		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobId, err)
 	}
-	log.Printf("instance id: %s\n", instance.Id)
+	log.Debugf("instance id: %s\n", instance.Id)
 
 	err = controller.TerminateInstance(ctx, ankacloud.TerminateInstanceRequest{
 		Id: instance.Id,
@@ -53,7 +53,7 @@ func executeCleanup(ctx context.Context, env gitlab.Environment) error {
 	if err != nil {
 		return fmt.Errorf("failed to terminate instance %q: %w", instance.Id, err)
 	}
-	log.Printf("Issuing termination request for instance %s\n", instance.Id)
+	log.Debugf("Issuing termination request for instance %s\n", instance.Id)
 
 	return nil
 }

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -20,7 +19,7 @@ var configCommand = &cobra.Command{
 			return fmt.Errorf("failed to get environment from context")
 		}
 
-		return executeConfig(cmd.Context(), env)
+		return executeConfig(env)
 	},
 }
 
@@ -37,20 +36,20 @@ type driver struct {
 	Version string `json:"version"`
 }
 
-func executeConfig(ctx context.Context, env gitlab.Environment) error {
+func executeConfig(env gitlab.Environment) error {
 	log.SetOutput(os.Stderr)
-	log.Println("running config stage")
+	log.Debugln("running config stage")
 
 	buildsDir := "/tmp/builds"
 	cacheDir := "/tmp/cache"
 
 	if env.BuildsDir != "" {
-		log.Printf("using supplied builds dir %q", env.BuildsDir)
+		log.Colorf("using supplied builds dir %q", env.BuildsDir)
 		buildsDir = env.BuildsDir
 	}
 
 	if env.CacheDir != "" {
-		log.Printf("using supplied cache dir %q", env.CacheDir)
+		log.Colorf("using supplied cache dir %q", env.CacheDir)
 		cacheDir = env.CacheDir
 	}
 

--- a/internal/command/prepare.go
+++ b/internal/command/prepare.go
@@ -67,7 +67,7 @@ func executePrepare(ctx context.Context, env gitlab.Environment) error {
 		VramMb:                  env.VmVramMb,
 	}
 
-	log.ConditionalColorf("Creating macOS VM with Template %q -- please be patient...", template)
+	log.Colorf("Creating macOS VM with Template %q -- please be patient...", template)
 	log.Debugf("payload %+v\n", req)
 	instanceId, err := controller.CreateInstance(ctx, req)
 	if err != nil {

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -29,6 +29,7 @@ func Execute(ctx context.Context) error {
 	}
 
 	log.SetDebug(env.Debug)
+	log.SetQuietLogging(env.QuietLogging)
 
 	return rootCmd.ExecuteContext(context.WithValue(ctx, contextKey("env"), env))
 }

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -33,7 +33,7 @@ var runCommand = &cobra.Command{
 func executeRun(ctx context.Context, env gitlab.Environment, args []string) error {
 	log.SetOutput(os.Stderr)
 
-	log.Printf("running run stage %s\n", args[1])
+	log.Debugf("running run stage %s\n", args[1])
 
 	apiClientConfig := getAPIClientConfig(env)
 	apiClient, err := ankacloud.NewAPIClient(apiClientConfig)
@@ -48,14 +48,12 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobId, err)
 	}
 
-	log.Printf("instance id: %s\n", instance.Id)
-
-	var nodeIp, nodeSshPort string
-	if instance.VM == nil {
+	var nodeSshPort string
+	if instance.VMInfo == nil {
 		return fmt.Errorf("instance has no VM: %+v", instance)
 	}
 
-	for _, rule := range instance.VM.PortForwardingRules {
+	for _, rule := range instance.VMInfo.PortForwardingRules {
 		if rule.VmPort == 22 && rule.Protocol == "tcp" {
 			nodeSshPort = fmt.Sprintf("%d", rule.NodePort)
 		}
@@ -63,22 +61,14 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 	if nodeSshPort == "" {
 		return fmt.Errorf("could not find ssh port forwarded for vm")
 	}
-	log.Printf("node SSH port to VM: %s\n", nodeSshPort)
-
-	nodeId := instance.NodeId
-	node, err := controller.GetNode(ctx, ankacloud.GetNodeRequest{Id: nodeId})
-	if err != nil {
-		return fmt.Errorf("failed to get node %s: %w", nodeId, err)
-	}
-	nodeIp = node.IP
-	log.Printf("node IP: %s\n", nodeIp)
+	log.Debugf("node SSH port to VM: %s\n", nodeSshPort)
 
 	gitlabScriptFile, err := os.Open(args[0])
 	if err != nil {
 		return fmt.Errorf("failed to open script file at %q: %w", args[0], err)
 	}
 	defer gitlabScriptFile.Close()
-	log.Printf("gitlab script path: %s", args[0])
+	log.Debugf("gitlab script path: %s", args[0])
 
 	sshUserName := env.SSHUserName
 	if sshUserName == "" {
@@ -98,7 +88,12 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 		},
 	}
 
-	addr := fmt.Sprintf("%s:%s", nodeIp, nodeSshPort)
+	node, err := controller.GetNode(ctx, ankacloud.GetNodeRequest{Id: instance.NodeId})
+	if err != nil {
+		return fmt.Errorf("failed to get node %s: %w", instance.NodeId, err)
+	}
+
+	addr := fmt.Sprintf("%s:%s", node.IP, nodeSshPort)
 	var sshClient *ssh.Client
 
 	// retry logic mimics what is done by the official Gitlab Runner (true for gitlab runner v16.7.0)
@@ -111,7 +106,7 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 		sshConnectionAttemptDelay = 5
 	}
 	for i := 0; i < maxAttempts; i++ {
-		log.Printf("attempt #%d to establish ssh connection to %q\n", i+1, addr)
+		log.Debugf("attempt #%d to establish ssh connection to %q\n", i+1, addr)
 		sshClient, err = ssh.Dial("tcp", addr, sshClientConfig)
 		if err == nil {
 			break
@@ -123,14 +118,14 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 	}
 	defer sshClient.Close()
 
-	log.Println("ssh connection established")
+	log.Debugln("ssh connection established")
 
 	session, err := sshClient.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to start new ssh session: %w", err)
 	}
 	defer session.Close()
-	log.Println("ssh session opened")
+	log.Debugln("ssh session opened")
 
 	session.Stdin = gitlabScriptFile
 	session.Stdout = os.Stdout
@@ -141,9 +136,9 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 		return fmt.Errorf("failed to start Shell on SSH session: %w", err)
 	}
 
-	log.Println("waiting for remote execution to finish")
+	log.Debugln("waiting for remote execution to finish")
 	err = session.Wait()
 
-	log.Println("remote execution finished")
+	log.Debugln("remote execution finished")
 	return err
 }

--- a/internal/gitlab/vars.go
+++ b/internal/gitlab/vars.go
@@ -19,7 +19,7 @@ const (
 var (
 	// Custom Executor vars
 	varDebug                     = ankaVar("DEBUG")
-	varQuietLogging              = ankaVar("QUIET_LOGGING")
+	varQuietLogging              = ankaVar("QUIETER_LOGGING")
 	varControllerURL             = ankaVar("CONTROLLER_URL")
 	varTemplateId                = ankaVar("TEMPLATE_ID")
 	varTemplateTag               = ankaVar("TEMPLATE_TAG")

--- a/internal/gitlab/vars.go
+++ b/internal/gitlab/vars.go
@@ -19,6 +19,7 @@ const (
 var (
 	// Custom Executor vars
 	varDebug                     = ankaVar("DEBUG")
+	varQuietLogging              = ankaVar("QUIET_LOGGING")
 	varControllerURL             = ankaVar("CONTROLLER_URL")
 	varTemplateId                = ankaVar("TEMPLATE_ID")
 	varTemplateTag               = ankaVar("TEMPLATE_TAG")
@@ -49,6 +50,7 @@ var (
 type Environment struct {
 	ControllerURL             string
 	Debug                     bool
+	QuietLogging              bool
 	TemplateId                string
 	TemplateTag               string
 	NodeId                    string
@@ -138,6 +140,13 @@ func InitEnv() (Environment, error) {
 			return e, fmt.Errorf("%w %q: %w", ErrInvalidVar, varDebug, err)
 		}
 		e.Debug = debug
+	}
+
+	if quietLogging, ok, err := GetBoolEnvVar(varQuietLogging); ok {
+		if err != nil {
+			return e, fmt.Errorf("%w %q: %w", ErrInvalidVar, varQuietLogging, err)
+		}
+		e.QuietLogging = quietLogging
 	}
 
 	if skip, ok, err := GetBoolEnvVar(varSkipTLSVerify); ok {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -6,20 +6,29 @@ import (
 	"log"
 )
 
+const (
+	BOLD_BLACK   = "\033[30;1m"
+	BOLD_RED     = "\033[31;1m"
+	BOLD_GREEN   = "\033[32;1m"
+	BOLD_YELLOW  = "\033[33;1m"
+	BOLD_BLUE    = "\033[34;1m"
+	BOLD_MAGENTA = "\033[35;1m"
+	BOLD_CYAN    = "\033[36;1m"
+	BOLD_WHITE   = "\033[37;1m"
+	YELLOW       = "\033[0;33m"
+	RESET        = "\033[0;m"
+	CLEAR        = "\033[0K"
+)
+
 var debug bool
+var quietLogging bool
 
 func SetDebug(active bool) {
 	debug = active
 }
 
-func Debug(msg string) {
-	Debugf("%s\n", msg)
-}
-
-func Debugf(format string, v ...any) {
-	if debug {
-		log.Printf(fmt.Sprintf("DEBUG: %s", format), v...)
-	}
+func SetQuietLogging(active bool) {
+	quietLogging = active
 }
 
 func SetOutput(w io.Writer) {
@@ -32,4 +41,74 @@ func Printf(format string, v ...any) {
 
 func Println(v ...any) {
 	log.Println(v...)
+}
+
+func Debugln(v ...any) {
+	Debugf("%s\n", v...)
+}
+
+func Debugf(format string, v ...any) {
+	if debug {
+		log.Printf(fmt.Sprintf("DEBUG: %s", format), v...)
+	}
+}
+
+func Warnf(format string, v ...any) {
+	log.Printf("%sWARN: %s%s", BOLD_YELLOW, fmt.Sprintf(format, v...), RESET)
+}
+
+func Warnln(v ...any) {
+	log.Printf("%sWARN: %s%s", BOLD_YELLOW, fmt.Sprint(v...), RESET)
+}
+
+func ConditionalWarnf(format string, v ...any) {
+	if !quietLogging {
+		Warnf(format, v...)
+	}
+}
+
+func ConditionalWarnln(v ...any) {
+	if !quietLogging {
+		Warnln(v...)
+	}
+}
+
+func Errorf(format string, v ...any) {
+	log.Printf("%sERROR: %s%s", BOLD_RED, fmt.Sprintf(format, v...), RESET)
+}
+
+func Errorln(v ...any) {
+	log.Printf("%sERROR: %s%s", BOLD_RED, fmt.Sprint(v...), RESET)
+}
+
+func ConditionalErrorf(format string, v ...any) {
+	if !quietLogging {
+		Errorf(format, v...)
+	}
+}
+
+func ConditionalErrorln(v ...any) {
+	if !quietLogging {
+		Errorln(v...)
+	}
+}
+
+func Colorf(format string, v ...any) {
+	log.Printf("%s%s%s", BOLD_MAGENTA, fmt.Sprintf(format, v...), RESET)
+}
+
+func Colorln(v ...any) {
+	log.Printf("%s%s%s", BOLD_MAGENTA, fmt.Sprint(v...), RESET)
+}
+
+func ConditionalColorf(format string, v ...any) {
+	if !quietLogging {
+		Colorf(format, v...)
+	}
+}
+
+func ConditionalColorln(v ...any) {
+	if !quietLogging {
+		Colorln(v...)
+	}
 }


### PR DESCRIPTION
- Added better logs that closely match our previous gitlab-runner integration with is now EOL:
```
2024/08/14 06:51:17 Creating macOS VM with Template "98ff7cc3-299c-4228-baba-870a768690bf" -- please be patient...
2024/08/14 06:51:28 instance a1ae3885-56bf-471e-5c39-c9251fe52405 is in state "Scheduling"
2024/08/14 06:51:38 instance a1ae3885-56bf-471e-5c39-c9251fe52405 is in state "Started"
2024/08/14 06:51:38 VM cloud_gitlab_integration_tests1-1723607479652434000 (a1ae3885-56bf-471e-5c39-c9251fe52405) is ready for work on node mini-arm-8 (10.8.1.48)
```
- Added `ANKA_CLOUD_QUIETER_LOGGING` boolean ENV for users to hide any unnecessary job logs.
- Less `instance {ID} is in state` logs to prevent long pulls from spamming the log.
- Log color change to match Veertu's main color.