### PR TITLE
release/v1.3.0

### DIFF
--- a/cmd/anka-cloud-gitlab-executor/main.go
+++ b/cmd/anka-cloud-gitlab-executor/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -10,6 +11,7 @@ import (
 	"github.com/veertuinc/anka-cloud-gitlab-executor/internal/command"
 	"github.com/veertuinc/anka-cloud-gitlab-executor/internal/gitlab"
 	"github.com/veertuinc/anka-cloud-gitlab-executor/internal/log"
+	"github.com/veertuinc/anka-cloud-gitlab-executor/internal/version"
 )
 
 var (
@@ -27,6 +29,12 @@ func main() {
 }
 
 func run() int {
+
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		fmt.Printf("%s", version.Get())
+		return 0
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
 	defer stop()
 

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -41,9 +41,9 @@ func executeCleanup(ctx context.Context, env gitlab.Environment) error {
 
 	controller := ankacloud.NewController(apiClient)
 
-	instance, err := controller.GetInstanceByExternalId(ctx, env.GitlabJobId)
+	instance, err := controller.GetInstanceByExternalId(ctx, env.GitlabJobUrl)
 	if err != nil {
-		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobId, err)
+		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobUrl, err)
 	}
 	log.Debugf("instance id: %s\n", instance.Id)
 

--- a/internal/command/prepare.go
+++ b/internal/command/prepare.go
@@ -69,10 +69,10 @@ func executePrepare(ctx context.Context, env gitlab.Environment) error {
 
 	var tagName string
 	if env.TemplateTag == "" {
-		tagName = "latest"
+		tagName = "(latest)"
 	}
 
-	log.Colorf("Creating macOS VM with Template %q and Tag \"%q\" -- please be patient...", template, tagName)
+	log.Colorf("Creating macOS VM with Template %q and Tag %q -- please be patient...", template, tagName)
 	log.Debugf("payload %+v\n", req)
 	instanceId, err := controller.CreateInstance(ctx, req)
 	if err != nil {

--- a/internal/command/prepare.go
+++ b/internal/command/prepare.go
@@ -54,7 +54,7 @@ func executePrepare(ctx context.Context, env gitlab.Environment) error {
 
 	req := ankacloud.CreateInstanceRequest{
 		TemplateId:              templateId,
-		ExternalId:              env.GitlabJobId,
+		ExternalId:              env.GitlabJobUrl,
 		Tag:                     env.TemplateTag,
 		NodeId:                  env.NodeId,
 		Priority:                env.Priority,

--- a/internal/command/prepare.go
+++ b/internal/command/prepare.go
@@ -67,7 +67,12 @@ func executePrepare(ctx context.Context, env gitlab.Environment) error {
 		VramMb:                  env.VmVramMb,
 	}
 
-	log.Colorf("Creating macOS VM with Template %q -- please be patient...", template)
+	var tagName string
+	if env.TemplateTag == "" {
+		tagName = "latest"
+	}
+
+	log.Colorf("Creating macOS VM with Template %q and Tag \"%q\" -- please be patient...", template, tagName)
 	log.Debugf("payload %+v\n", req)
 	instanceId, err := controller.CreateInstance(ctx, req)
 	if err != nil {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -43,9 +43,9 @@ func executeRun(ctx context.Context, env gitlab.Environment, args []string) erro
 
 	controller := ankacloud.NewController(apiClient)
 
-	instance, err := controller.GetInstanceByExternalId(ctx, env.GitlabJobId)
+	instance, err := controller.GetInstanceByExternalId(ctx, env.GitlabJobUrl)
 	if err != nil {
-		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobId, err)
+		return fmt.Errorf("failed to get instance by external id %q: %w", env.GitlabJobUrl, err)
 	}
 
 	var nodeSshPort string

--- a/internal/gitlab/vars.go
+++ b/internal/gitlab/vars.go
@@ -43,7 +43,7 @@ var (
 	varVmVcpu                    = ankaVar("VM_VCPU")
 
 	// Gitlab vars
-	varGitlabJobId     = gitlabVar("CI_JOB_ID")
+	varGitlabJobUrl    = gitlabVar("CI_JOB_URL")
 	varGitlabJobStatus = gitlabVar("CI_JOB_STATUS")
 )
 
@@ -64,7 +64,7 @@ type Environment struct {
 	SSHPassword               string
 	SSHAttempts               int
 	SSHConnectionAttemptDelay int
-	GitlabJobId               string
+	GitlabJobUrl              string
 	CustomHttpHeaders         map[string]string
 	KeepAliveOnError          bool
 	GitlabJobStatus           jobStatus
@@ -105,8 +105,8 @@ func InitEnv() (Environment, error) {
 		return e, fmt.Errorf("%w %q: missing http prefix", ErrInvalidVar, e.ControllerURL)
 	}
 
-	if e.GitlabJobId, ok = os.LookupEnv(varGitlabJobId); !ok {
-		return e, fmt.Errorf("%w: %s", ErrMissingVar, varGitlabJobId)
+	if e.GitlabJobUrl, ok = os.LookupEnv(varGitlabJobUrl); !ok {
+		return e, fmt.Errorf("%w: %s", ErrMissingVar, varGitlabJobUrl)
 	}
 
 	if os.Getenv(varSshUserName) != "" {

--- a/internal/gitlab/vars_test.go
+++ b/internal/gitlab/vars_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestControllerWithTrailingSlash(t *testing.T) {
 	os.Setenv(varControllerURL, "http://fake-controller-url/")
-	os.Setenv(varGitlabJobId, "fake-gitlab-job-id")
+	os.Setenv(varGitlabJobUrl, "fake-gitlab-job-url")
 	defer os.Clearenv()
 
 	env, err := InitEnv()
@@ -24,7 +24,7 @@ func TestControllerWithTrailingSlash(t *testing.T) {
 
 func TestCustomHttpHeadersEnvVar(t *testing.T) {
 	os.Setenv(varControllerURL, "http://fake-controller-url")
-	os.Setenv(varGitlabJobId, "fake-gitlab-job-id")
+	os.Setenv(varGitlabJobUrl, "fake-gitlab-job-url")
 	os.Setenv(varCustomHTTPHeaders, "{\"fake-header\":\"fake-value\", \"fake-header2\":\"fake-value2\"}")
 	defer os.Clearenv()
 	env, err := InitEnv()
@@ -74,8 +74,8 @@ func TestGitlabJobIdMissing(t *testing.T) {
 	if !errors.Is(err, ErrMissingVar) {
 		t.Errorf("expected error %q, got %q", ErrMissingVar, err)
 	}
-	if !strings.Contains(err.Error(), varGitlabJobId) {
-		t.Errorf("expected error to contain %q, got %q", varGitlabJobId, err)
+	if !strings.Contains(err.Error(), varGitlabJobUrl) {
+		t.Errorf("expected error to contain %q, got %q", varGitlabJobUrl, err)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestInvalidVram(t *testing.T) {
 	for _, tc := range testCases {
 		os.Clearenv()
 		os.Setenv(varControllerURL, "http://fake-controller-url")
-		os.Setenv(varGitlabJobId, "fake-gitlab-job-id")
+		os.Setenv(varGitlabJobUrl, "fake-gitlab-job-url")
 
 		os.Setenv(varVmVcpu, tc.vram)
 
@@ -141,8 +141,7 @@ func TestInvalidVcpu(t *testing.T) {
 	for _, tc := range testCases {
 		os.Clearenv()
 		os.Setenv(varControllerURL, "http://fake-controller-url")
-		os.Setenv(varGitlabJobId, "fake-gitlab-job-id")
-
+		os.Setenv(varGitlabJobUrl, "fake-gitlab-job-url")
 		os.Setenv(varVmVcpu, tc.vcpu)
 
 		_, err := InitEnv()


### PR DESCRIPTION
- Added Tag to log line about template (`(latest)` if not specified)
- Allowing `--version` to be ran without other args
- Using Gitlab Job URL instead of an ID for External ID